### PR TITLE
Fix stopListening occasionally crashing

### DIFF
--- a/android/src/main/kotlin/com/oval/sms_receiver/SmsReceiverPlugin.kt
+++ b/android/src/main/kotlin/com/oval/sms_receiver/SmsReceiverPlugin.kt
@@ -92,8 +92,13 @@ class SmsReceiverPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
   }
 
   private fun stopListening() {
-    activity.unregisterReceiver(smsBroadcastReceiver)
-    isListening = false
+    try {
+      activity.unregisterReceiver(smsBroadcastReceiver)
+    } catch (e: Exception) {
+      // Ignored
+    } finally {
+      isListening = false
+    }
   }
 
   override fun onAttachedToActivity(binding: ActivityPluginBinding) {


### PR DESCRIPTION
When `stopListening` is called, the plugin is crashing on some old Huawei devices (maybe there are others too)